### PR TITLE
Fix to issue #35

### DIFF
--- a/scripts/GetNetworkSecurityType.sh
+++ b/scripts/GetNetworkSecurityType.sh
@@ -6,4 +6,4 @@
 # Created by Chetan Surpur on 10/26/10.
 # Copyright 2010 Chetan Surpur. All rights reserved.
 
-printf %s `/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk '/link auth/ {print $3}'`
+printf %s `/usr/libexec/authopen /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk '/link auth/ {print $3}'`

--- a/scripts/TurnProxyOff.sh
+++ b/scripts/TurnProxyOff.sh
@@ -13,4 +13,4 @@ fi
 
 DEVICENAME=$1
 
-networksetup -setsocksfirewallproxystate $DEVICENAME off
+/usr/libexec/authopen networksetup -setsocksfirewallproxystate $DEVICENAME off

--- a/scripts/TurnProxyOn.sh
+++ b/scripts/TurnProxyOn.sh
@@ -14,6 +14,6 @@ fi
 DEVICENAME=$1
 LOCALPORT=$2
 
-networksetup -setsocksfirewallproxy $DEVICENAME 127.0.0.1 $LOCALPORT
-networksetup -setproxybypassdomains $DEVICENAME *.local localhost 127.0.0.1 169.254/16 192.168/16 172.16.0.0/12 10.0.0.0/8
-networksetup -setsocksfirewallproxystate $DEVICENAME on
+/usr/libexec/authopen networksetup -setsocksfirewallproxy $DEVICENAME 127.0.0.1 $LOCALPORT
+/usr/libexec/authopen networksetup -setproxybypassdomains $DEVICENAME *.local localhost 127.0.0.1 169.254/16 192.168/16 172.16.0.0/12 10.0.0.0/8
+/usr/libexec/authopen networksetup -setsocksfirewallproxystate $DEVICENAME on


### PR DESCRIPTION
scripts that require root perms (those that call network setup) keep
asking for password multiple times in OS X 10.8 (Mountain Lion). This
fix solves this issue
