### PR TITLE
Fix to multiple authorizations requests (issue #35)

### DIFF
--- a/AppController.h
+++ b/AppController.h
@@ -67,6 +67,8 @@
 	Boolean SSHConnected;
 	
 	NSString *currentNetworkSecurityType;
+    
+    BOOL lion; //OSX version (important to choose "Airport" vs "Wi-Fi")
 }
 
 - (void)openSSHConnectionAfterDelay :(int)delay;
@@ -76,6 +78,7 @@
 - (void)closeVPNConnection;
 - (void)setRunOnLogin :(BOOL)value;
 
+- (void)showAuthorizationErrorSidestepDialog;
 - (void)showRestartSidestepDialog;
 
 - (void)updateUIForVPNServiceList;

--- a/AppController.m
+++ b/AppController.m
@@ -84,6 +84,10 @@ NSInteger GrowlSpam_TestConnection					= 0;
 		SSHConnected = FALSE;
 		
 		currentNetworkSecurityType = nil;
+        
+        SInt32 version = 0;
+        Gestalt( gestaltSystemVersion, &version );
+        lion = ( version >= 0x1070 );
     }
 	
     return self;	
@@ -508,36 +512,36 @@ NSInteger GrowlSpam_TestConnection					= 0;
 
 - (void)turnWirelessProxyOnThread :(NSNumber *)port {
 	
-	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+	@autoreleasepool {
     
-    // Snow Leopard
-	if (![proxySetter turnAirportProxyOn:port]) {
-		[self showRestartSidestepDialog];
-	}
-    
-    // Lion
-    if (![proxySetter turnWiFiProxyOn:port]) {
-		[self showRestartSidestepDialog];
-	}
+        if(lion) {
+            if (![proxySetter toggleProxy:TRUE interface:@"Wi-Fi" port:port]) {
+                [self showAuthorizationErrorSidestepDialog];
+            }
+        } else {
+            if (![proxySetter toggleProxy:TRUE interface:@"Airport" port:port]) {
+                [self showAuthorizationErrorSidestepDialog];
+            }
+        }
 	
-	[pool release];
+    }
 }
 
 - (void)turnWirelessProxyOffThread {
 	
-	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-	
-    // Snow Leopard
-    if (![proxySetter turnAirportProxyOff]) {
-		[self showRestartSidestepDialog];
+	@autoreleasepool {
+
+        if(lion) {
+            if (![proxySetter toggleProxy:FALSE interface:@"Wi-Fi" port:0]) {
+                [self showAuthorizationErrorSidestepDialog];
+            }
+        } else {
+            if (![proxySetter toggleProxy:FALSE interface:@"Airport" port:0]) {
+                [self showAuthorizationErrorSidestepDialog];
+            }
+        }
+        
 	}
-    
-    // Lion
-    if (![proxySetter turnWiFiProxyOff]) {
-		[self showRestartSidestepDialog];
-	}
-    
-	[pool release];
 }
 
 - (void)openVPNConnectionAfterDelayThread {
@@ -949,6 +953,23 @@ NSInteger GrowlSpam_TestConnection					= 0;
 	// Growl Spam Reduction reset.  This allows messages to appear if the user connects to a different network of the same type.
 	GrowlSpam_ConnectionType = 0;
 	
+}
+
+- (void)showAuthorizationErrorSidestepDialog {
+    
+    XLog(self, @"Showing user Authorization Error Sidestep dialog");
+	
+	[NSApp activateIgnoringOtherApps:YES];	// Allows windows of this app to become front
+	
+	NSRunCriticalAlertPanel(	@"Error accessing your System Preferences",
+                            @"It seems that you didn't allow Sidestep to modify your System Preferences.\n\n"
+                            "Please close and open Sidestep again in order to ensure smooth running,"
+                            "by authorizing Sidestep to modify your System.\n\n"
+                            "Until you do so, you will not benefit from Sidestep functionalities.",
+                            @"OK",
+                            nil,
+                            nil,
+                            nil);
 }
 
 - (void)showRestartSidestepDialog {

--- a/AppController.m
+++ b/AppController.m
@@ -125,10 +125,8 @@ NSInteger GrowlSpam_TestConnection					= 0;
 	if (previousPID != 0) {
 		XLog(self, @"Turning proxy off");
 		
-		[NSThread detachNewThreadSelector:@selector(turnWirelessProxyOffThread)
-								 toTarget:self
-							   withObject:nil];
-		
+		[self turnWirelessProxyOffThread];
+
 		// Terminate previous SSH connection attempt if still running
 		[NSThread detachNewThreadSelector:@selector(terminateSSHConnectionAttemptThread)
 								 toTarget:self
@@ -256,10 +254,8 @@ NSInteger GrowlSpam_TestConnection					= 0;
 		// Operate based on user's decision
 		if (decision == NSAlertDefaultReturn) {	// Answer was "Yes"
 			XLog(self, @"Turning proxy off");
-			[NSThread detachNewThreadSelector:@selector(turnWirelessProxyOffThread)
-									 toTarget:self
-								   withObject:nil];
-			
+            [self turnWirelessProxyOffThread];
+						
 			if (SSHConnection) {
 				XLog(self, @"Killing current SSH connection");
 				[SSHConnection terminate];
@@ -329,9 +325,7 @@ NSInteger GrowlSpam_TestConnection					= 0;
 - (void)closeSSHConnection {
 	if (SSHConnection) {
 		XLog(self, @"Turning proxy off");
-		[NSThread detachNewThreadSelector:@selector(turnWirelessProxyOffThread)
-								 toTarget:self
-							   withObject:nil];
+        [self turnWirelessProxyOffThread];
 		
 		XLog(self, @"Killing current SSH connection");
 		[SSHConnection terminate];
@@ -652,10 +646,9 @@ NSInteger GrowlSpam_TestConnection					= 0;
 		XLog(self, @"Turning proxy on");
 		NSNumber *localport = (NSNumber *)[defaultsController getLocalPortNumber];
 		
-		[NSThread detachNewThreadSelector:@selector(turnWirelessProxyOnThread:)
-								 toTarget:self
-							   withObject:[NSNumber numberWithInt:[localport intValue]]];
-		[self performSelectorOnMainThread:@selector(updateUIForSSHConnectionOpened) withObject:nil waitUntilDone:FALSE];
+        [self turnWirelessProxyOnThread:[NSNumber numberWithInt:[localport intValue]]];
+		
+        [self performSelectorOnMainThread:@selector(updateUIForSSHConnectionOpened) withObject:nil waitUntilDone:FALSE];
 	}
 	
 }
@@ -717,9 +710,7 @@ NSInteger GrowlSpam_TestConnection					= 0;
 	
 	if (SSHConnected) {
 		XLog(self, @"Turning proxy off");
-		[NSThread detachNewThreadSelector:@selector(turnWirelessProxyOffThread)
-								 toTarget:self
-							   withObject:nil];
+        [self turnWirelessProxyOffThread];
 	}
 	
 	if (!testingConnection) {

--- a/ProxySetter.h
+++ b/ProxySetter.h
@@ -9,15 +9,11 @@
 #import <Cocoa/Cocoa.h>
 
 @interface ProxySetter : NSObject {
-
+    AuthorizationRef       auth;
+    AuthorizationFlags rootFlags;
 }
+- (BOOL)toggleProxy:(BOOL)on interface:(NSString *)interface port:(NSNumber *)port;
 
-- (BOOL)turnAirportProxyOn:(NSNumber *)port;
-- (BOOL)turnWiFiProxyOn:(NSNumber *)port;
-- (BOOL)turnProxyOn:(NSNumber *)port interface:(NSString *)interface;
-
-- (BOOL)turnAirportProxyOff;
-- (BOOL)turnWiFiProxyOff;
-- (BOOL)turnProxyOff:(NSString *)interface;
+- (void)dealloc;
 
 @end

--- a/ProxySetter.m
+++ b/ProxySetter.m
@@ -8,13 +8,15 @@
 
 #import "ProxySetter.h"
 #import "AppUtilities.h"
-
+#import <SystemConfiguration/SCNetworkConfiguration.h>
+#import <SystemConfiguration/SCPreferences.h>
+#import <SystemConfiguration/SCDynamicStore.h>
 
 @implementation ProxySetter
 
 /*
  *	Switches Airport's SOCKS proxy to the SSH tunnel previously opened.
- *	
+ *
  *	return: true on success
  *	return: false if task path not found
  */
@@ -22,12 +24,12 @@
 - (BOOL)turnAirportProxyOn:(NSNumber *)port {
     
     return [self turnProxyOn:port interface:@"Airport"];
-
+    
 }
 
 /*
  *	Switches WiFi's SOCKS proxy to the SSH tunnel previously opened.
- *	
+ *
  *	return: true on success
  *	return: false if task path not found
  */
@@ -40,53 +42,116 @@
 
 /*
  *	Switches given interface's SOCKS proxy to the SSH tunnel previously opened.
- *	
+ *
  *	return: true on success
  *	return: false if task path not found
  */
 
 - (BOOL)turnProxyOn:(NSNumber *)port interface:(NSString *)interface {
+
+    BOOL success = FALSE;
 	
 	XLog(self, @"Turning proxy on for port: %@", port);
-	
-	NSTask *task = [[[NSTask alloc] init] autorelease];
-	
-	// Setup the pipes on the task
-	NSPipe *outputPipe = [NSPipe pipe];
-	NSPipe *errorPipe = [NSPipe pipe];
-	
-	[task setStandardOutput:outputPipe];
-	[task setStandardInput:[NSFileHandle fileHandleWithNullDevice]];
-	[task setStandardError:errorPipe];
-	
-	// Set up arguments to the task
-	NSArray *args = [NSArray arrayWithObjects:	[NSString stringWithString:interface],
-												[NSString stringWithFormat:@"%d", [port intValue]],
-												nil];
-	
-	// Get the path of the task, which is included as part of the main application bundle
-	NSString *taskPath = [NSBundle pathForResource:@"TurnProxyOn"
-											ofType:@"sh"
-									   inDirectory:[[NSBundle mainBundle] bundlePath]];
-	
-	if (!taskPath) {
-		return FALSE;
-	}
-	
-	// Set task's arguments and launch path
-	[task setArguments:args];
-	[task setLaunchPath:taskPath];
-	
-	// Launch task
-	[task launch];
-	
-	return TRUE;
+    
+    OSStatus               authErr = noErr;
+    AuthorizationRef       auth;
+    
+    // Get Authorization
+    AuthorizationFlags rootFlags = kAuthorizationFlagDefaults
+    |  kAuthorizationFlagExtendRights
+    |  kAuthorizationFlagInteractionAllowed
+    |  kAuthorizationFlagPreAuthorize;
+    authErr = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, rootFlags, &auth);
+    
+    if (authErr != noErr) {
+        XLog(self, [NSString stringWithFormat:@" Error in AuthorizationCreate, CODE: %d", authErr]);
+        goto freeAuth;
+    }
+    
+    // Get System Preferences Lock
+    SCPreferencesRef prefsRef = SCPreferencesCreateWithAuthorization(NULL, CFSTR("sidestep"), NULL, auth);
+    success = SCPreferencesLock(prefsRef, NO);
+    if (!success) {
+        XLog(self, @"Fail to obtain PreferencesLock");
+        goto freePrefsRef;
+    }
+    
+    // Get available network services
+    SCNetworkSetRef networkSetRef = SCNetworkSetCopyCurrent(prefsRef);
+    if(networkSetRef == NULL)
+        goto freeNetworkSetRef;
+    
+    //Look up interface entry
+    CFArrayRef networkServicesArrayRef = SCNetworkSetCopyServices(networkSetRef);
+    SCNetworkServiceRef networkServiceRef = NULL;
+    for (long i = 0; i < CFArrayGetCount(networkServicesArrayRef); i++) {
+        networkServiceRef = CFArrayGetValueAtIndex(networkServicesArrayRef, i);
+        if([(NSString *)SCNetworkServiceGetName(networkServiceRef) isEqualToString:interface])
+            break;
+        else
+            networkServiceRef = NULL;
+    }
+    if (networkServiceRef == NULL) {
+        XLog(self, [NSString stringWithFormat:@"No system interface matching %@", interface]);
+        goto freeNetworkServicesArrayRef;
+    }
+    
+    XLog(self, [NSString stringWithFormat:@"Setting proxy on device %@", (NSString*)SCNetworkServiceGetName(networkServiceRef)]);
+
+    // Get proxy protocol
+    SCNetworkProtocolRef proxyProtocolRef = SCNetworkServiceCopyProtocol(networkServiceRef, kSCNetworkProtocolTypeProxies);
+    if(proxyProtocolRef == NULL) {
+        XLog(self, @"Couldn't acquire copy of proxyProtocol");
+        goto freeResources;
+    }
+    
+    NSDictionary *oldPreferences = (NSDictionary*)SCNetworkProtocolGetConfiguration(proxyProtocolRef);
+    NSString *wantedHost = @"localhost";
+    
+    [oldPreferences setValue: wantedHost forKey:(NSString*)kSCPropNetProxiesSOCKSProxy];
+    [oldPreferences setValue:[NSNumber numberWithInt:1] forKey:(NSString*)kSCPropNetProxiesSOCKSEnable];
+    [oldPreferences setValue:[NSNumber numberWithInteger:[port integerValue]] forKey:(NSString*)kSCPropNetProxiesSOCKSPort];
+    
+    success = SCNetworkProtocolSetConfiguration(proxyProtocolRef, (CFDictionaryRef)oldPreferences);
+    if(!success) {
+        XLog(self, @"Failed to set Protocol Configuration");
+        goto freeResources;
+    }
+    
+    success = SCPreferencesCommitChanges(prefsRef);
+    if(!success) {
+        XLog(self, @"Failed to Commit Changes");
+        goto freeResources;
+    }
+    
+    success = SCPreferencesApplyChanges(prefsRef);
+    if(!success) {
+        XLog(self, @"Failed to Apply Changes");
+        goto freeResources;
+    }
+    
+    success = TRUE;
+    
+    //Free Resources
+freeResources:
+    CFRelease(proxyProtocolRef);
+freeNetworkServicesArrayRef:
+    CFRelease(networkServicesArrayRef);
+freeNetworkSetRef:
+	CFRelease(networkSetRef);    
+freePrefsRef:
+    SCPreferencesUnlock(prefsRef);
+    CFRelease(prefsRef);
+freeAuth:
+    AuthorizationFree(auth, rootFlags);
+        
+    return success;
 	
 }
 
 /*
  *	Switches Airport's SOCKS proxy off.
- *	
+ *
  *	return: true on success
  *	return: false if task path not found
  */
@@ -99,7 +164,7 @@
 
 /*
  *	Switches WiFi's SOCKS proxy off.
- *	
+ *
  *	return: true on success
  *	return: false if task path not found
  */
@@ -112,13 +177,13 @@
 
 /*
  *	Switches given interface's SOCKS proxy off.
- *	
+ *
  *	return: true on success
  *	return: false if task path not found
  */
 
 - (BOOL)turnProxyOff:(NSString *)interface {
-
+    
 	XLog(self, @"Turning proxy off");
 	
 	NSTask *task = [[[NSTask alloc] init] autorelease];
@@ -132,7 +197,7 @@
 	[task setStandardError:errorPipe];
 	
 	// Set up arguments to the task
-	NSArray *args = [NSArray arrayWithObject:[NSString stringWithString:interface]];	
+	NSArray *args = [NSArray arrayWithObject:[NSString stringWithString:interface]];
 	
 	// Get the path of the task, which is included as part of the main application bundle
 	NSString *taskPath = [NSBundle pathForResource:@"TurnProxyOff"
@@ -141,7 +206,7 @@
 	
 	if (!taskPath) {
 		return FALSE;
-	}	
+	}
 	
 	// Set task's arguments and launch path
 	[task setArguments:args];

--- a/ProxySetter.m
+++ b/ProxySetter.m
@@ -43,6 +43,7 @@
 
 - (BOOL)toggleProxy:(BOOL)on interface:(NSString *)interface port:(NSNumber *)port {
 
+    XLog(self, [NSString stringWithFormat:@"toggleProxy %d on interface %@ using port %@", on, interface, port]);
     BOOL success = FALSE;
 	
     
@@ -61,8 +62,10 @@
     
     // Get available network services
     SCNetworkSetRef networkSetRef = SCNetworkSetCopyCurrent(prefsRef);
-    if(networkSetRef == NULL)
+    if(networkSetRef == NULL) {
+        XLog(self, @"Fail to get available network services");
         goto freeNetworkSetRef;
+    }
     
     //Look up interface entry
     CFArrayRef networkServicesArrayRef = SCNetworkSetCopyServices(networkSetRef);

--- a/ProxySetter.m
+++ b/ProxySetter.m
@@ -3,6 +3,7 @@
 //  Sidestep
 //
 //  Created by Chetan Surpur on 11/18/10.
+//  Modified by Diogo Gomes on 8/8/12.
 //  Copyright 2010 Chetan Surpur. All rights reserved.
 //
 
@@ -14,58 +15,40 @@
 
 @implementation ProxySetter
 
-/*
- *	Switches Airport's SOCKS proxy to the SSH tunnel previously opened.
- *
- *	return: true on success
- *	return: false if task path not found
- */
-
-- (BOOL)turnAirportProxyOn:(NSNumber *)port {
-    
-    return [self turnProxyOn:port interface:@"Airport"];
-    
-}
-
-/*
- *	Switches WiFi's SOCKS proxy to the SSH tunnel previously opened.
- *
- *	return: true on success
- *	return: false if task path not found
- */
-
-- (BOOL)turnWiFiProxyOn:(NSNumber *)port {
-    
-    return [self turnProxyOn:port interface:@"Wi-Fi"];
-    
-}
-
-/*
- *	Switches given interface's SOCKS proxy to the SSH tunnel previously opened.
- *
- *	return: true on success
- *	return: false if task path not found
- */
-
-- (BOOL)turnProxyOn:(NSNumber *)port interface:(NSString *)interface {
-
-    BOOL success = FALSE;
-	
-	XLog(self, @"Turning proxy on for port: %@", port);
-    
+- (id) init
+{
+    XLog(self, @"Get Auth");
     OSStatus               authErr = noErr;
-    AuthorizationRef       auth;
     
     // Get Authorization
-    AuthorizationFlags rootFlags = kAuthorizationFlagDefaults
+    rootFlags = kAuthorizationFlagDefaults
     |  kAuthorizationFlagExtendRights
     |  kAuthorizationFlagInteractionAllowed
     |  kAuthorizationFlagPreAuthorize;
     authErr = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, rootFlags, &auth);
-    
     if (authErr != noErr) {
-        XLog(self, [NSString stringWithFormat:@" Error in AuthorizationCreate, CODE: %d", authErr]);
-        goto freeAuth;
+        auth = NULL;
+    }
+    return self;
+}
+
+/*
+ * Toggle proxy ON/OFF
+ *
+ * return true on success
+ * return false if an error occurs
+ *
+ */
+
+
+- (BOOL)toggleProxy:(BOOL)on interface:(NSString *)interface port:(NSNumber *)port {
+
+    BOOL success = FALSE;
+	
+    
+    if (auth == NULL) {
+        XLog(self, [NSString stringWithFormat:@"No authorization has been granted to modify network configuration"]);
+        return success;
     }
     
     // Get System Preferences Lock
@@ -96,7 +79,7 @@
         goto freeNetworkServicesArrayRef;
     }
     
-    XLog(self, [NSString stringWithFormat:@"Setting proxy on device %@", (NSString*)SCNetworkServiceGetName(networkServiceRef)]);
+    XLog(self, [NSString stringWithFormat:@"Setting proxy for device %@", (NSString*)SCNetworkServiceGetName(networkServiceRef)]);
 
     // Get proxy protocol
     SCNetworkProtocolRef proxyProtocolRef = SCNetworkServiceCopyProtocol(networkServiceRef, kSCNetworkProtocolTypeProxies);
@@ -108,10 +91,14 @@
     NSDictionary *oldPreferences = (NSDictionary*)SCNetworkProtocolGetConfiguration(proxyProtocolRef);
     NSString *wantedHost = @"localhost";
     
-    [oldPreferences setValue: wantedHost forKey:(NSString*)kSCPropNetProxiesSOCKSProxy];
-    [oldPreferences setValue:[NSNumber numberWithInt:1] forKey:(NSString*)kSCPropNetProxiesSOCKSEnable];
-    [oldPreferences setValue:[NSNumber numberWithInteger:[port integerValue]] forKey:(NSString*)kSCPropNetProxiesSOCKSPort];
-    
+    if(on) {//Turn proxy configuration ON
+        [oldPreferences setValue: wantedHost forKey:(NSString*)kSCPropNetProxiesSOCKSProxy];
+        [oldPreferences setValue:[NSNumber numberWithInt:1] forKey:(NSString*)kSCPropNetProxiesSOCKSEnable];
+        [oldPreferences setValue:[NSNumber numberWithInteger:[port integerValue]] forKey:(NSString*)kSCPropNetProxiesSOCKSPort];
+    } else {//Turn proxy configuration OFF
+        [oldPreferences setValue:[NSNumber numberWithInt:0] forKey:(NSString*)kSCPropNetProxiesSOCKSEnable];
+    }
+        
     success = SCNetworkProtocolSetConfiguration(proxyProtocolRef, (CFDictionaryRef)oldPreferences);
     if(!success) {
         XLog(self, @"Failed to set Protocol Configuration");
@@ -129,7 +116,7 @@
         XLog(self, @"Failed to Apply Changes");
         goto freeResources;
     }
-    
+    // If we reach this point that it's a wrap!
     success = TRUE;
     
     //Free Resources
@@ -142,81 +129,17 @@ freeNetworkSetRef:
 freePrefsRef:
     SCPreferencesUnlock(prefsRef);
     CFRelease(prefsRef);
-freeAuth:
-    AuthorizationFree(auth, rootFlags);
         
     return success;
-	
 }
 
-/*
- *	Switches Airport's SOCKS proxy off.
- *
- *	return: true on success
- *	return: false if task path not found
- */
 
-- (BOOL)turnAirportProxyOff {
-	
-    return [self turnProxyOff:@"Airport"];
+-(void)dealloc {
+    XLog(self, @"dealloc ProxySetter");
     
-}
-
-/*
- *	Switches WiFi's SOCKS proxy off.
- *
- *	return: true on success
- *	return: false if task path not found
- */
-
-- (BOOL)turnWiFiProxyOff {
-	
-    return [self turnProxyOff:@"Wi-Fi"];
+    AuthorizationFree(auth, rootFlags);
     
-}
-
-/*
- *	Switches given interface's SOCKS proxy off.
- *
- *	return: true on success
- *	return: false if task path not found
- */
-
-- (BOOL)turnProxyOff:(NSString *)interface {
-    
-	XLog(self, @"Turning proxy off");
-	
-	NSTask *task = [[[NSTask alloc] init] autorelease];
-	
-	// Setup the pipes on the task
-	NSPipe *outputPipe = [NSPipe pipe];
-	NSPipe *errorPipe = [NSPipe pipe];
-	
-	[task setStandardOutput:outputPipe];
-	[task setStandardInput:[NSFileHandle fileHandleWithNullDevice]];
-	[task setStandardError:errorPipe];
-	
-	// Set up arguments to the task
-	NSArray *args = [NSArray arrayWithObject:[NSString stringWithString:interface]];
-	
-	// Get the path of the task, which is included as part of the main application bundle
-	NSString *taskPath = [NSBundle pathForResource:@"TurnProxyOff"
-											ofType:@"sh"
-									   inDirectory:[[NSBundle mainBundle] bundlePath]];
-	
-	if (!taskPath) {
-		return FALSE;
-	}
-	
-	// Set task's arguments and launch path
-	[task setArguments:args];
-	[task setLaunchPath:taskPath];
-	
-	// Launch task
-	[task launch];
-	
-	return TRUE;
-	
+    [super dealloc];
 }
 
 @end


### PR DESCRIPTION
This patch fixes issue #35 by substituting the external bash scripts with the native SCFramework.

Since the error messages no longer made sense (those associated with the app path), I new dialog was added  providing proper feedback to the user.

Code was also added to detect OSX version and to only try the proper interface (avoiding failed actions in the system preferences)
